### PR TITLE
feat(tools): add read-only discord_history tool with late-bound runtime handle

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -226,6 +226,7 @@ class AgentLoop:
         runtime_events: RuntimeEventBus | None = None,
         runtime_model_publisher: Callable[[str, str | None], None] | None = None,
         vision_handoff: Any = None,
+        discord_runtime_handle: Any | None = None,
     ):
         from nanobot.config.schema import ToolsConfig
 
@@ -237,6 +238,7 @@ class AgentLoop:
         self.channels_config = channels_config
         self.provider = provider
         self.vision_handoff = vision_handoff
+        self._discord_runtime_handle = discord_runtime_handle
         self._provider_snapshot_loader = provider_snapshot_loader
         self._preset_snapshot_loader = preset_snapshot_loader
         self._runtime_model_publisher = runtime_model_publisher
@@ -548,6 +550,7 @@ class AgentLoop:
             timezone=self.context.timezone or "UTC",
             workspace_sandbox=self.workspace_scopes.sandbox_status,
             runtime_events=self.runtime_events,
+            discord_runtime_handle=self._discord_runtime_handle,
         )
         loader = ToolLoader()
         registered = loader.load(ctx, self.tools)

--- a/nanobot/agent/tools/context.py
+++ b/nanobot/agent/tools/context.py
@@ -59,3 +59,8 @@ class ToolContext:
     timezone: str = "UTC"
     workspace_sandbox: Any | None = None
     runtime_events: Any | None = None
+    # Late-bound Discord runtime handle; created by the gateway before
+    # AgentLoop construction and bound to the live DiscordChannel after
+    # ChannelManager starts. ``DiscordHistoryTool`` resolves the connected
+    # client through it at execution time. None outside the gateway.
+    discord_runtime_handle: Any | None = None

--- a/nanobot/agent/tools/discord_history.py
+++ b/nanobot/agent/tools/discord_history.py
@@ -1,0 +1,573 @@
+"""Read-only Discord history tool with a late-bound runtime handle."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.tools.base import Tool, tool_parameters
+
+DISCORD_AVAILABLE = importlib.util.find_spec("discord") is not None
+if DISCORD_AVAILABLE:
+    import discord
+if TYPE_CHECKING:
+    import discord
+
+
+_DEFAULT_LIMIT = 500
+_MAX_LIMIT = 2000
+_DEFAULT_PER_SOURCE = 200
+_MAX_PER_SOURCE = 500
+_DEFAULT_ARCHIVED = 50
+_MAX_ARCHIVED = 200
+_DEFAULT_MAX_CHARS = 12000
+_MAX_MAX_CHARS = 16000
+
+
+class DiscordRuntimeHandle:
+    """Late-bound mutable holder for the live Discord channel.
+
+    Created before ``AgentLoop`` construction (so tool registration can
+    retain it) and bound to the running ``DiscordChannel`` after
+    ``ChannelManager`` starts. ``DiscordHistoryTool`` resolves the
+    connected client through this handle at execution time, which keeps
+    tool registration independent of the Discord client lifecycle and
+    makes the same bound handle available to isolated cron turns that
+    share the agent's tool registry.
+    """
+
+    def __init__(self) -> None:
+        self._channel: Any = None
+
+    def bind(self, channel: Any) -> None:
+        """Bind the handle to a running ``DiscordChannel`` (or None to clear)."""
+        self._channel = channel
+
+    @property
+    def channel(self) -> Any | None:
+        """The bound ``DiscordChannel`` (may be None if Discord is disabled)."""
+        return self._channel
+
+    def resolve_client(self) -> Any | None:
+        """Return the connected, ready discord.py client, or None."""
+        ch = self._channel
+        if ch is None:
+            return None
+        client = ch.client
+        if client is None or not client.is_ready():
+            return None
+        return client
+
+
+def _parse_iso(value: str | None, field: str) -> datetime | None | str:
+    """Parse an ISO-8601 datetime; return None, or an error string."""
+    if value is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return f"Error: {field} must be ISO-8601; got {value!r}"
+    if dt.tzinfo is None:
+        return f"Error: {field} must be timezone-aware; got {value!r}"
+    return dt.astimezone(timezone.utc)
+
+
+def _valid_snowflake(value: str | None, field: str) -> str | None:
+    """Return None if valid, or an error string."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.isdigit():
+        return f"Error: {field} must be a numeric Discord id string"
+    return None
+
+
+@tool_parameters(
+    {
+        "type": "object",
+        "properties": {
+            "guild_id": {
+                "type": "string",
+                "description": (
+                    "Discord guild id. May be omitted only when the bot is in "
+                    "exactly one guild; otherwise required."
+                ),
+            },
+            "channel_id": {
+                "type": "string",
+                "description": (
+                    "Fetch only this text channel, forum post/thread, or thread. "
+                    "When omitted, scan eligible configured sources in the guild."
+                ),
+            },
+            "since": {
+                "type": "string",
+                "description": "ISO-8601 lower bound (exclusive, UTC normalized).",
+            },
+            "until": {
+                "type": "string",
+                "description": "ISO-8601 upper bound (exclusive, UTC normalized).",
+            },
+            "limit": {
+                "type": "integer",
+                "description": f"Global max returned messages (default {_DEFAULT_LIMIT}, max {_MAX_LIMIT}).",
+                "minimum": 1,
+                "maximum": _MAX_LIMIT,
+            },
+            "per_source_limit": {
+                "type": "integer",
+                "description": f"Max messages fetched from one source (default {_DEFAULT_PER_SOURCE}, max {_MAX_PER_SOURCE}).",
+                "minimum": 1,
+                "maximum": _MAX_PER_SOURCE,
+            },
+            "include_threads": {
+                "type": "boolean",
+                "description": "Include accessible active threads/forum posts (default true).",
+            },
+            "include_archived_threads": {
+                "type": "boolean",
+                "description": (
+                    "Also include archived public threads/posts and joined private "
+                    "archives (default false)."
+                ),
+            },
+            "archived_thread_limit": {
+                "type": "integer",
+                "description": f"Max archived threads enumerated per parent (default {_DEFAULT_ARCHIVED}, max {_MAX_ARCHIVED}).",
+                "minimum": 1,
+                "maximum": _MAX_ARCHIVED,
+            },
+            "max_chars": {
+                "type": "integer",
+                "description": f"Serialized result budget (default {_DEFAULT_MAX_CHARS}, max {_MAX_MAX_CHARS}).",
+                "minimum": 1,
+                "maximum": _MAX_MAX_CHARS,
+            },
+        },
+    }
+)
+class DiscordHistoryTool(Tool):
+    """Fetch past Discord messages from one configured guild (read-only)."""
+
+    _scopes = {"core"}
+
+    def __init__(self, handle: DiscordRuntimeHandle) -> None:
+        self._handle = handle
+
+    @classmethod
+    def enabled(cls, ctx: Any) -> bool:
+        return ctx.discord_runtime_handle is not None
+
+    @classmethod
+    def create(cls, ctx: Any) -> Tool:
+        return cls(handle=ctx.discord_runtime_handle)
+
+    @property
+    def name(self) -> str:
+        return "discord_history"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Fetch past Discord messages from one configured guild as a bounded, "
+            "read-only structured result. Respects the bot's allow_channels and "
+            "effective view_channel + read_message_history permissions. Requires "
+            "the MESSAGE_CONTENT intent for text content."
+        )
+
+    @property
+    def read_only(self) -> bool:
+        return True
+
+    async def execute(
+        self,
+        *,
+        guild_id: str | None = None,
+        channel_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = _DEFAULT_LIMIT,
+        per_source_limit: int = _DEFAULT_PER_SOURCE,
+        include_threads: bool = True,
+        include_archived_threads: bool = False,
+        archived_thread_limit: int = _DEFAULT_ARCHIVED,
+        max_chars: int = _DEFAULT_MAX_CHARS,
+        **kwargs: Any,
+    ) -> str:
+        if not DISCORD_AVAILABLE:
+            return (
+                "Error: discord.py is not installed. "
+                "Run: pip install nanobot-ai[discord]"
+            )
+
+        handle = self._handle
+        channel = handle.channel
+        client = handle.resolve_client()
+        if channel is None or client is None:
+            return (
+                "Error: Discord is not connected or not ready. "
+                "This tool only works in the gateway with Discord enabled."
+            )
+
+        # --- parameter validation ---
+        err = _valid_snowflake(guild_id, "guild_id")
+        if err:
+            return err
+        err = _valid_snowflake(channel_id, "channel_id")
+        if err:
+            return err
+        since_dt = _parse_iso(since, "since")
+        if isinstance(since_dt, str):
+            return since_dt
+        until_dt = _parse_iso(until, "until")
+        if isinstance(until_dt, str):
+            return until_dt
+        if since_dt and until_dt and since_dt >= until_dt:
+            return "Error: since must be earlier than until"
+        if limit <= 0 or limit > _MAX_LIMIT:
+            return f"Error: limit must be in 1..{_MAX_LIMIT}"
+        if per_source_limit <= 0 or per_source_limit > _MAX_PER_SOURCE:
+            return f"Error: per_source_limit must be in 1..{_MAX_PER_SOURCE}"
+        if archived_thread_limit <= 0 or archived_thread_limit > _MAX_ARCHIVED:
+            return f"Error: archived_thread_limit must be in 1..{_MAX_ARCHIVED}"
+        if max_chars <= 0 or max_chars > _MAX_MAX_CHARS:
+            return f"Error: max_chars must be in 1..{_MAX_MAX_CHARS}"
+
+        # --- guild resolution ---
+        guild = self._resolve_guild(client, guild_id)
+        if isinstance(guild, str):
+            return guild
+
+        # --- source collection ---
+        if channel_id is not None:
+            sources = await self._resolve_explicit_sources(
+                channel, client, guild, channel_id,
+                include_threads, include_archived_threads, archived_thread_limit,
+            )
+            if isinstance(sources, str):
+                return sources
+            skipped = 0
+            discovery_warnings: list[str] = []
+        else:
+            sources, skipped, discovery_warnings = await self._discover_sources(
+                channel, client, guild,
+                include_threads, include_archived_threads, archived_thread_limit,
+            )
+
+        if not sources:
+            result = self._empty_result(guild, since_dt, until_dt, skipped, discovery_warnings)
+            return self._serialize_result(result, max_chars)
+
+        # --- bounded fetch ---
+        collected: list[Any] = []
+        warnings = list(discovery_warnings)
+        scanned = 0
+        for src in sources:
+            remaining = limit - len(collected)
+            if remaining <= 0:
+                break
+            fetch_limit = min(per_source_limit, remaining)
+            scanned += 1
+            try:
+                async for msg in src.history(
+                    after=since_dt, before=until_dt, limit=fetch_limit, oldest_first=True,
+                ):
+                    collected.append(msg)
+            except Exception as e:
+                warnings.append(f"fetch failed in {self._src_label(src)}: {e}")
+                continue
+
+        collected.sort(key=lambda m: (m.created_at, m.id))
+        if len(collected) > limit:
+            collected = collected[:limit]
+
+        messages = [self._serialize_message(m) for m in collected]
+        result = {
+            "guild": {"id": str(guild.id), "name": guild.name},
+            "window": {
+                "since": since_dt.isoformat() if since_dt else None,
+                "until": until_dt.isoformat() if until_dt else None,
+            },
+            "messages": messages,
+            "sources": {"scanned": scanned, "skipped": skipped},
+            "truncated": False,
+            "warnings": warnings,
+        }
+        return self._serialize_result(result, max_chars)
+
+    # --- guild / source resolution ---
+
+    def _resolve_guild(self, client: Any, guild_id: str | None) -> Any | str:
+        if guild_id is not None:
+            guild = client.get_guild(int(guild_id))
+            if guild is None:
+                return f"Error: guild {guild_id} not found or not accessible"
+            return guild
+        guilds = list(client.guilds)
+        if len(guilds) == 1:
+            return guilds[0]
+        if not guilds:
+            return "Error: bot is not in any guild"
+        return (
+            "Error: bot is in multiple guilds; guild_id is required. "
+            f"Connected guilds: {len(guilds)}"
+        )
+
+    async def _bot_member(self, guild: Any, client: Any) -> Any | None:
+        me = getattr(guild, "me", None)
+        if me is not None:
+            return me
+        user = getattr(client, "user", None)
+        if user is None:
+            return None
+        try:
+            return await guild.fetch_member(user.id)
+        except Exception:
+            return None
+
+    def _can_read(self, source: Any, me: Any) -> bool:
+        if me is None:
+            return False
+        try:
+            perms = source.permissions_for(me)
+        except Exception:
+            return False
+        return bool(getattr(perms, "view_channel", False)) and bool(
+            getattr(perms, "read_message_history", False)
+        )
+
+    async def _resolve_explicit_sources(
+        self,
+        channel: Any,
+        client: Any,
+        guild: Any,
+        channel_id: str,
+        include_threads: bool,
+        include_archived: bool,
+        archived_limit: int,
+    ) -> list[Any] | str:
+        try:
+            cid = int(channel_id)
+        except (TypeError, ValueError):
+            return "Error: channel_id must be a numeric Discord id string"
+        src = client.get_channel(cid)
+        if src is None:
+            try:
+                src = await client.fetch_channel(cid)
+            except Exception:
+                src = None
+        if src is None:
+            return "Error: channel not available to this bot configuration"
+        src_guild = getattr(src, "guild", None)
+        if src_guild is None or src_guild.id != guild.id:
+            return "Error: channel not available to this bot configuration"
+        if not channel.is_channel_allowed(src):
+            return "Error: channel not available to this bot configuration"
+        me = await self._bot_member(guild, client)
+
+        if isinstance(src, discord.ForumChannel):
+            posts: list[Any] = []
+            if include_threads:
+                for thread in src.threads:
+                    if channel.is_channel_allowed(thread) and self._can_read(thread, me):
+                        posts.append(thread)
+            if include_archived:
+                try:
+                    async for thread in src.archived_threads(limit=archived_limit):
+                        if channel.is_channel_allowed(thread) and self._can_read(thread, me):
+                            posts.append(thread)
+                except Exception as e:
+                    return f"Error: failed enumerating archived forum posts: {e}"
+            if not posts:
+                return "Error: no accessible threads in that forum"
+            return posts
+
+        if isinstance(src, discord.Thread):
+            if not self._can_read(src, me):
+                return "Error: channel not available to this bot configuration"
+            return [src]
+
+        if isinstance(src, discord.TextChannel):
+            if not self._can_read(src, me):
+                return "Error: channel not available to this bot configuration"
+            return [src]
+
+        return "Error: channel not available to this bot configuration"
+
+    async def _discover_sources(
+        self,
+        channel: Any,
+        client: Any,
+        guild: Any,
+        include_threads: bool,
+        include_archived: bool,
+        archived_limit: int,
+    ) -> tuple[list[Any], int, list[str]]:
+        sources: list[Any] = []
+        skipped = 0
+        warnings: list[str] = []
+        seen: set[int] = set()
+        me = await self._bot_member(guild, client)
+
+        def try_add(src: Any) -> None:
+            nonlocal skipped
+            if src is None:
+                return
+            sid = getattr(src, "id", None)
+            if sid is None or sid in seen:
+                return
+            if not channel.is_channel_allowed(src):
+                skipped += 1
+                return
+            if not self._can_read(src, me):
+                skipped += 1
+                return
+            seen.add(sid)
+            sources.append(src)
+
+        for tc in guild.text_channels:
+            try_add(tc)
+
+        if include_threads:
+            for forum in guild.forum_channels:
+                if not channel.is_channel_allowed(forum) or not self._can_read(forum, me):
+                    continue
+                for thread in forum.threads:
+                    try_add(thread)
+            try:
+                active = await guild.active_threads()
+            except Exception as e:
+                warnings.append(f"active_threads failed: {e}")
+                active = []
+            for thread in active:
+                try_add(thread)
+
+        if include_archived:
+            for tc in list(sources):
+                if not isinstance(tc, discord.TextChannel):
+                    continue
+                try:
+                    async for thread in tc.archived_threads(
+                        private=False, joined=False, limit=archived_limit
+                    ):
+                        try_add(thread)
+                    async for thread in tc.archived_threads(
+                        private=True, joined=True, limit=archived_limit
+                    ):
+                        try_add(thread)
+                except Exception as e:
+                    warnings.append(f"archived_threads failed in {tc.name}: {e}")
+            for forum in guild.forum_channels:
+                if not channel.is_channel_allowed(forum) or not self._can_read(forum, me):
+                    continue
+                try:
+                    async for thread in forum.archived_threads(limit=archived_limit):
+                        try_add(thread)
+                except Exception as e:
+                    warnings.append(f"archived_threads failed in {forum.name}: {e}")
+
+        return sources, skipped, warnings
+
+    # --- serialization ---
+
+    def _empty_result(
+        self,
+        guild: Any,
+        since_dt: datetime | None,
+        until_dt: datetime | None,
+        skipped: int,
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        return {
+            "guild": {"id": str(guild.id), "name": guild.name},
+            "window": {
+                "since": since_dt.isoformat() if since_dt else None,
+                "until": until_dt.isoformat() if until_dt else None,
+            },
+            "messages": [],
+            "sources": {"scanned": 0, "skipped": skipped},
+            "truncated": False,
+            "warnings": warnings,
+        }
+
+    def _serialize_message(self, msg: Any) -> dict[str, Any]:
+        ch = msg.channel
+        author = msg.author
+        author_name = (
+            getattr(author, "display_name", None)
+            or getattr(author, "name", None)
+            or str(getattr(author, "id", ""))
+        )
+        if isinstance(ch, discord.Thread):
+            parent = getattr(ch, "parent", None)
+            channel_id = str(parent.id) if parent else None
+            channel_name = getattr(parent, "name", None) if parent else None
+            thread_id = str(ch.id)
+            thread_name = getattr(ch, "name", None)
+        else:
+            channel_id = str(getattr(ch, "id", ""))
+            channel_name = getattr(ch, "name", None)
+            thread_id = None
+            thread_name = None
+        ref = getattr(msg, "reference", None)
+        reply_to = (
+            str(ref.message_id)
+            if ref and getattr(ref, "message_id", None)
+            else None
+        )
+        mtype = getattr(msg, "type", None)
+        mtype_name = getattr(mtype, "name", None) or str(mtype)
+        attachments = [
+            {"filename": a.filename, "url": a.url} for a in (msg.attachments or [])
+        ]
+        embeds = [
+            {
+                "type": getattr(e, "type", None),
+                "title": getattr(e, "title", None),
+                "url": getattr(e, "url", None),
+            }
+            for e in (msg.embeds or [])
+        ]
+        created_at = getattr(msg, "created_at", None)
+        return {
+            "message_id": str(msg.id),
+            "channel_id": channel_id,
+            "channel": channel_name,
+            "thread_id": thread_id,
+            "thread": thread_name,
+            "author_id": str(getattr(author, "id", "")),
+            "author": author_name,
+            "timestamp": created_at.isoformat() if created_at else None,
+            "message_type": mtype_name,
+            "content": msg.content or "",
+            "reply_to": reply_to,
+            "attachments": attachments,
+            "embeds": embeds,
+        }
+
+    def _src_label(self, src: Any) -> str:
+        name = getattr(src, "name", None) or ""
+        return f"{getattr(src, 'id', '?')}:{name}"
+
+    def _serialize_result(self, result: dict[str, Any], max_chars: int) -> str:
+        all_msgs = result["messages"]
+        prefix = {k: v for k, v in result.items() if k != "messages"}
+        prefix_str = json.dumps(prefix, separators=(",", ":"), ensure_ascii=False)
+        # prefix_str includes `"messages":[]`; the real payload replaces `[]`
+        # with the kept messages, so reserve two chars for that swap.
+        budget = max_chars - len(prefix_str) + 2
+        parts: list[str] = []
+        total = 0
+        truncated = False
+        for m in all_msgs:
+            mj = json.dumps(m, separators=(",", ":"), ensure_ascii=False)
+            extra = (1 if parts else 0) + len(mj)
+            if total + extra > budget:
+                truncated = True
+                break
+            parts.append(mj)
+            total += extra
+        result["messages"] = [json.loads(p) for p in parts]
+        result["truncated"] = truncated or bool(result.get("truncated", False))
+        return json.dumps(result, separators=(",", ":"), ensure_ascii=False)

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -391,6 +391,29 @@ class DiscordChannel(BaseChannel):
     def _forget_channel(self, channel_or_id: Any) -> None:
         self._known_channels.pop(self._channel_key(channel_or_id), None)
 
+    @property
+    def client(self) -> Any | None:
+        """Read-only access to the connected discord.py client, or None.
+
+        Tools and runtime plumbing resolve the live client through this
+        accessor at execution time (after ``start`` has connected) rather
+        than reaching into private ``_client`` state.
+        """
+        return self._client
+
+    def is_channel_allowed(self, channel: Any) -> bool:
+        """Return True if *channel* (or its parent) satisfies allow_channels.
+
+        Reuses the existing channel-key/parent-key allowlist semantics so
+        history access never broadens Discord configuration. When
+        ``allow_channels`` is empty, the bot's effective Discord
+        permissions are the only gate.
+        """
+        allow = self.config.allow_channels
+        if not allow:
+            return True
+        return not self._channel_allow_keys(channel).isdisjoint(allow)
+
     async def start(self) -> None:
         """Start the Discord client."""
         if not DISCORD_AVAILABLE:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -700,6 +700,19 @@ def _run_gateway(
     cron_store_path = config.workspace_path / "cron" / "jobs.json"
     cron = CronService(cron_store_path)
 
+    # Late-bound Discord runtime handle: created now so DiscordHistoryTool can
+    # register against it during AgentLoop construction, then bound to the live
+    # DiscordChannel after ChannelManager starts (see below).
+    from nanobot.agent.tools.discord_history import DiscordRuntimeHandle
+
+    discord_section = getattr(config.channels, "discord", None)
+    discord_enabled = bool(
+        discord_section.get("enabled", False)
+        if isinstance(discord_section, dict)
+        else getattr(discord_section, "enabled", False)
+    )
+    discord_runtime = DiscordRuntimeHandle() if discord_enabled else None
+
     # Create agent with cron service
     agent = AgentLoop.from_config(
         config, bus,
@@ -712,6 +725,7 @@ def _run_gateway(
         provider_snapshot_loader=load_provider_snapshot,
         runtime_events=runtime_events,
         provider_signature=provider_snapshot.signature,
+        discord_runtime_handle=discord_runtime,
     )
 
     from nanobot.bus.events import OutboundMessage
@@ -935,6 +949,18 @@ def _run_gateway(
         session_manager=session_manager,
         cron_service=cron,
     )
+
+    # Bind the Discord runtime handle to the live channel now that it exists.
+    # The handle stays None-resolving until DiscordChannel.start() connects.
+    if discord_runtime is not None:
+        discord_channel = channels.get_channel("discord")
+        if discord_channel is not None:
+            discord_runtime.bind(discord_channel)
+        else:
+            logger.warning(
+                "Discord history tool enabled but discord channel is not "
+                "available; tool will report not-ready until Discord starts."
+            )
 
     def _pick_heartbeat_target() -> tuple[str, str]:
         """Pick a routable channel/chat target for heartbeat-triggered messages."""

--- a/tests/agent/tools/test_discord_history_tool.py
+++ b/tests/agent/tools/test_discord_history_tool.py
@@ -1,0 +1,668 @@
+"""Tests for the read-only discord_history tool and its late-bound handle."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("discord")
+import discord  # noqa: E402
+
+from nanobot.agent.tools.context import ToolContext  # noqa: E402
+from nanobot.agent.tools.discord_history import (  # noqa: E402
+    DiscordHistoryTool,
+    DiscordRuntimeHandle,
+)
+from nanobot.agent.tools.loader import ToolLoader  # noqa: E402
+from nanobot.bus.queue import MessageBus  # noqa: E402
+from nanobot.channels.discord import DiscordChannel, DiscordConfig  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fake discord.py object builders (spec-bound so isinstance() works)
+# ---------------------------------------------------------------------------
+
+
+async def _aiter(items):
+    for item in items:
+        yield item
+
+
+def _history_factory(messages):
+    def _history(*, after=None, before=None, limit=None, oldest_first=None):
+        out = list(messages)
+        if after is not None:
+            out = [m for m in out if m.created_at > after]
+        if before is not None:
+            out = [m for m in out if m.created_at < before]
+        if oldest_first:
+            out.sort(key=lambda m: (m.created_at, m.id))
+        if limit is not None:
+            out = out[:limit]
+        return _aiter(out)
+
+    return _history
+
+
+def _perms(*, view=True, history=True):
+    p = MagicMock(spec=discord.Permissions)
+    p.view_channel = view
+    p.read_message_history = history
+    return p
+
+
+def _make_author(aid, *, name="user", display=None):
+    return SimpleNamespace(id=aid, name=name, display_name=display or name)
+
+
+def _make_msg(
+    mid,
+    content,
+    *,
+    channel,
+    author=None,
+    created_at=None,
+    mtype="default",
+    reply_to=None,
+    attachments=(),
+    embeds=(),
+):
+    msg = SimpleNamespace()
+    msg.id = mid
+    msg.content = content
+    msg.channel = channel
+    msg.author = author or _make_author(1)
+    msg.created_at = created_at or datetime(2024, 1, 1, tzinfo=timezone.utc)
+    msg.type = SimpleNamespace(name=mtype)
+    msg.reference = SimpleNamespace(message_id=reply_to) if reply_to else None
+    msg.attachments = list(attachments)
+    msg.embeds = list(embeds)
+    return msg
+
+
+def _make_member():
+    return MagicMock(spec=discord.Member)
+
+
+def _make_text(cid, name, *, guild, perms=None, messages=(), archived=()):
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = cid
+    ch.name = name
+    ch.guild = guild
+    ch.permissions_for = MagicMock(return_value=perms or _perms())
+    ch.history = _history_factory(messages)
+    ch.archived_threads = MagicMock(side_effect=lambda **kw: _aiter(list(archived)))
+    return ch
+
+
+def _make_thread(tid, name, *, parent, perms=None, messages=()):
+    th = MagicMock(spec=discord.Thread)
+    th.id = tid
+    th.name = name
+    th.parent_id = parent.id
+    th.parent = parent
+    th.guild = parent.guild
+    th.permissions_for = MagicMock(return_value=perms or _perms())
+    th.history = _history_factory(messages)
+    return th
+
+
+def _make_forum(fid, name, *, guild, perms=None, threads=(), archived=()):
+    ch = MagicMock(spec=discord.ForumChannel)
+    ch.id = fid
+    ch.name = name
+    ch.guild = guild
+    ch.permissions_for = MagicMock(return_value=perms or _perms())
+    ch.threads = list(threads)
+    ch.archived_threads = MagicMock(side_effect=lambda **kw: _aiter(list(archived)))
+    return ch
+
+
+def _make_guild(
+    gid=1,
+    name="Guild",
+    *,
+    text_channels=(),
+    forums=(),
+    active_threads=(),
+    me=None,
+):
+    g = MagicMock(spec=discord.Guild)
+    g.id = gid
+    g.name = name
+    g.text_channels = list(text_channels)
+    g.forum_channels = list(forums)
+    g.me = me or _make_member()
+    g.active_threads = AsyncMock(return_value=list(active_threads))
+    return g
+
+
+def _make_client(guilds):
+    registry: dict[int, object] = {}
+    for g in guilds:
+        for tc in g.text_channels:
+            registry[tc.id] = tc
+        for f in g.forum_channels:
+            registry[f.id] = f
+            for t in f.threads:
+                registry[t.id] = t
+        for t in g.active_threads.return_value:
+            registry[t.id] = t
+
+    client = MagicMock(spec=discord.Client)
+    client.is_ready.return_value = True
+    client.user = SimpleNamespace(id=999)
+    client.guilds = list(guilds)
+    by_gid = {g.id: g for g in guilds}
+    client.get_guild = MagicMock(side_effect=lambda gid: by_gid.get(gid))
+    client.get_channel = MagicMock(side_effect=lambda cid: registry.get(cid))
+
+    async def _fetch_channel(cid):
+        found = registry.get(cid)
+        if found is None:
+            raise discord.NotFound(MagicMock(), "unknown channel")
+        return found
+
+    client.fetch_channel = AsyncMock(side_effect=_fetch_channel)
+    return client
+
+
+def _make_setup(*, allow_channels=(), guilds=()):
+    cfg = DiscordConfig(allow_channels=list(allow_channels))
+    ch = DiscordChannel(cfg, MessageBus())
+    ch._client = _make_client(guilds)
+    handle = DiscordRuntimeHandle()
+    handle.bind(ch)
+    tool = DiscordHistoryTool(handle=handle)
+    return tool, ch
+
+
+# ---------------------------------------------------------------------------
+# Handle lifecycle / readiness
+# ---------------------------------------------------------------------------
+
+
+def test_handle_unbound_resolves_none():
+    handle = DiscordRuntimeHandle()
+    assert handle.channel is None
+    assert handle.resolve_client() is None
+
+
+def test_enabled_requires_handle():
+    ctx_with = ToolContext(config=None, workspace=".", discord_runtime_handle=DiscordRuntimeHandle())
+    ctx_without = ToolContext(config=None, workspace=".")
+    assert DiscordHistoryTool.enabled(ctx_with) is True
+    assert DiscordHistoryTool.enabled(ctx_without) is False
+
+
+def test_tool_not_registered_without_handle():
+    ctx = ToolContext(config=None, workspace=".")
+    loader = ToolLoader(test_classes=[DiscordHistoryTool])
+    registry = MagicMock()
+    registry.has.return_value = False
+    loader.load(ctx, registry, scope="core")
+    registry.register.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_dependency_error(monkeypatch):
+    tool, _ = _make_setup(guilds=[_make_guild()])
+    monkeypatch.setattr(
+        "nanobot.agent.tools.discord_history.DISCORD_AVAILABLE", False
+    )
+    result = await tool.execute()
+    assert "discord.py is not installed" in result
+
+
+@pytest.mark.asyncio
+async def test_not_ready_when_client_unset():
+    cfg = DiscordConfig()
+    ch = DiscordChannel(cfg, MessageBus())
+    handle = DiscordRuntimeHandle()
+    handle.bind(ch)  # _client is None
+    tool = DiscordHistoryTool(handle=handle)
+    result = await tool.execute()
+    assert "not connected or not ready" in result
+
+
+@pytest.mark.asyncio
+async def test_not_ready_when_client_not_ready():
+    tool, ch = _make_setup(guilds=[_make_guild()])
+    ch._client.is_ready.return_value = False
+    result = await tool.execute()
+    assert "not connected or not ready" in result
+
+
+# ---------------------------------------------------------------------------
+# Guild resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_guild_omitted_ok_when_single_guild():
+    tc = _make_text(10, "general", guild=None)
+    guild = _make_guild(text_channels=[tc])
+    tc.guild = guild
+    tool, _ = _make_setup(guilds=[guild])
+    result = await tool.execute()
+    data = json.loads(result)
+    assert data["guild"]["id"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_guild_omitted_ambiguous_requires_guild_id():
+    g1 = _make_guild(gid=1)
+    g2 = _make_guild(gid=2)
+    tool, _ = _make_setup(guilds=[g1, g2])
+    result = await tool.execute()
+    assert "multiple guilds" in result
+    assert "guild_id is required" in result
+
+
+@pytest.mark.asyncio
+async def test_guild_not_found():
+    tool, _ = _make_setup(guilds=[_make_guild(gid=1)])
+    result = await tool.execute(guild_id="999")
+    assert "not found" in result
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_snowflake_rejected():
+    tool, _ = _make_setup(guilds=[_make_guild()])
+    assert "numeric" in await tool.execute(guild_id="abc")
+    assert "numeric" in await tool.execute(channel_id="xyz")
+
+
+@pytest.mark.asyncio
+async def test_naive_datetime_rejected():
+    tool, _ = _make_setup(guilds=[_make_guild()])
+    result = await tool.execute(since="2024-01-01T00:00:00")
+    assert "timezone-aware" in result
+
+
+@pytest.mark.asyncio
+async def test_since_greater_equal_until_rejected():
+    tool, _ = _make_setup(guilds=[_make_guild()])
+    ts = "2024-01-01T00:00:00+00:00"
+    assert "earlier than" in await tool.execute(since=ts, until=ts)
+
+
+@pytest.mark.asyncio
+async def test_out_of_range_limits_rejected():
+    tool, _ = _make_setup(guilds=[_make_guild()])
+    assert "limit must be in" in await tool.execute(limit=0)
+    assert "limit must be in" in await tool.execute(limit=99999)
+    assert "per_source_limit must be in" in await tool.execute(per_source_limit=0)
+    assert "max_chars must be in" in await tool.execute(max_chars=0)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist + permissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_allowlist_denies_unlisted_channel():
+    listed = _make_text(10, "general", guild=None)
+    unlisted = _make_text(20, "other", guild=None)
+    guild = _make_guild(text_channels=[listed, unlisted])
+    listed.guild = guild
+    unlisted.guild = guild
+    listed.history = _history_factory([_make_msg(1, "hi", channel=listed)])
+    unlisted.history = _history_factory([_make_msg(2, "nope", channel=unlisted)])
+    tool, _ = _make_setup(allow_channels=["10"], guilds=[guild])
+    data = json.loads(await tool.execute())
+    fetched = {m["channel_id"] for m in data["messages"]}
+    assert fetched == {"10"}
+    # the unlisted channel was skipped (not a fetch failure, but not scanned)
+    assert data["sources"]["skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_allowlist_parent_thread_semantics():
+    parent = _make_text(10, "general", guild=None)
+    thread = _make_thread(100, "topic", parent=parent)
+    guild = _make_guild(text_channels=[parent], active_threads=[thread])
+    parent.guild = guild
+    tool, _ = _make_setup(allow_channels=["10"], guilds=[guild])
+    data = json.loads(await tool.execute())
+    # thread's parent is listed, so the thread is eligible
+    assert any(m["thread_id"] == "100" for m in data["messages"]) or data["sources"]["scanned"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_disallowed_channel_generic_error():
+    unlisted = _make_text(20, "other", guild=None)
+    guild = _make_guild(text_channels=[unlisted])
+    unlisted.guild = guild
+    tool, _ = _make_setup(allow_channels=["10"], guilds=[guild])
+    result = await tool.execute(channel_id="20")
+    assert "not available to this bot configuration" in result
+
+
+@pytest.mark.asyncio
+async def test_permission_denied_source_skipped():
+    ok = _make_text(10, "general", guild=None, messages=[_make_msg(1, "hi", channel=None)])
+    locked = _make_text(
+        20, "locked", guild=None, perms=_perms(view=False, history=False)
+    )
+    guild = _make_guild(text_channels=[ok, locked])
+    ok.guild = guild
+    locked.guild = guild
+    ok.messages_ref = [_make_msg(1, "hi", channel=ok)]
+    ok.history = _history_factory([_make_msg(1, "hi", channel=ok)])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute())
+    assert data["sources"]["skipped"] == 1
+    assert all(m["channel_id"] == "10" for m in data["messages"])
+
+
+@pytest.mark.asyncio
+async def test_explicit_no_read_permission_generic_error():
+    locked = _make_text(20, "locked", guild=None, perms=_perms(view=False, history=False))
+    guild = _make_guild(text_channels=[locked])
+    locked.guild = guild
+    tool, _ = _make_setup(guilds=[guild])
+    result = await tool.execute(channel_id="20")
+    assert "not available to this bot configuration" in result
+
+
+# ---------------------------------------------------------------------------
+# Output ordering and caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_global_chronological_order_across_sources():
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    tc1 = _make_text(10, "a", guild=None)
+    tc2 = _make_text(20, "b", guild=None)
+    guild = _make_guild(text_channels=[tc1, tc2])
+    tc1.guild = guild
+    tc2.guild = guild
+    tc1.history = _history_factory([
+        _make_msg(2, "second", channel=tc1, created_at=base.replace(hour=2)),
+        _make_msg(1, "first", channel=tc1, created_at=base.replace(hour=1)),
+    ])
+    tc2.history = _history_factory([
+        _make_msg(3, "third", channel=tc2, created_at=base.replace(hour=3)),
+    ])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute())
+    ids = [int(m["message_id"]) for m in data["messages"]]
+    assert ids == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_global_limit_cap():
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    tc1 = _make_text(10, "a", guild=None)
+    tc2 = _make_text(20, "b", guild=None)
+    guild = _make_guild(text_channels=[tc1, tc2])
+    tc1.guild = guild
+    tc2.guild = guild
+    tc1.history = _history_factory([
+        _make_msg(1, "m1", channel=tc1, created_at=base),
+        _make_msg(2, "m2", channel=tc1, created_at=base.replace(hour=1)),
+    ])
+    tc2.history = _history_factory([
+        _make_msg(3, "m3", channel=tc2, created_at=base.replace(hour=2)),
+        _make_msg(4, "m4", channel=tc2, created_at=base.replace(hour=3)),
+    ])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(limit=2))
+    assert len(data["messages"]) == 2
+    assert [int(m["message_id"]) for m in data["messages"]] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_per_source_limit_cap():
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    tc1 = _make_text(10, "a", guild=None)
+    tc2 = _make_text(20, "b", guild=None)
+    guild = _make_guild(text_channels=[tc1, tc2])
+    tc1.guild = guild
+    tc2.guild = guild
+    tc1.history = _history_factory([
+        _make_msg(1, "m1", channel=tc1, created_at=base),
+        _make_msg(2, "m2", channel=tc1, created_at=base.replace(hour=1)),
+    ])
+    tc2.history = _history_factory([
+        _make_msg(3, "m3", channel=tc2, created_at=base.replace(hour=2)),
+        _make_msg(4, "m4", channel=tc2, created_at=base.replace(hour=3)),
+    ])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(limit=10, per_source_limit=1))
+    # one message per source
+    assert len(data["messages"]) == 2
+    assert {int(m["message_id"]) for m in data["messages"]} == {1, 3}
+
+
+@pytest.mark.asyncio
+async def test_max_chars_truncation_flag():
+    tc = _make_text(10, "a", guild=None)
+    guild = _make_guild(text_channels=[tc])
+    tc.guild = guild
+    big = "x" * 500
+    tc.history = _history_factory([
+        _make_msg(i, big, channel=tc, created_at=datetime(2024, 1, 1, tzinfo=timezone.utc).replace(hour=i))
+        for i in range(1, 20)
+    ])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(limit=20, max_chars=1000))
+    assert data["truncated"] is True
+    assert len(data["messages"]) < 20
+
+
+# ---------------------------------------------------------------------------
+# Source discovery: text, forum posts, active threads, archived, dedup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_channel_direct_fetch():
+    tc = _make_text(10, "general", guild=None)
+    guild = _make_guild(text_channels=[tc])
+    tc.guild = guild
+    tc.history = _history_factory([_make_msg(5, "hello", channel=tc)])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(channel_id="10"))
+    assert len(data["messages"]) == 1
+    assert data["messages"][0]["content"] == "hello"
+    assert data["messages"][0]["channel"] == "general"
+
+
+@pytest.mark.asyncio
+async def test_forum_parent_returns_posts():
+    forum = _make_forum(50, "dev", guild=None)
+    post = _make_thread(500, "intro", parent=forum)
+    forum.threads = [post]
+    guild = _make_guild(forums=[forum])
+    forum.guild = guild
+    post.history = _history_factory([_make_msg(7, "post msg", channel=post)])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(channel_id="50"))
+    assert len(data["messages"]) == 1
+    assert data["messages"][0]["thread_id"] == "500"
+
+
+@pytest.mark.asyncio
+async def test_thread_direct_fetch():
+    parent = _make_text(10, "general", guild=None)
+    thread = _make_thread(100, "topic", parent=parent)
+    guild = _make_guild(text_channels=[parent], active_threads=[thread])
+    parent.guild = guild
+    thread.guild = guild
+    thread.history = _history_factory([_make_msg(8, "in thread", channel=thread)])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(channel_id="100"))
+    assert len(data["messages"]) == 1
+    assert data["messages"][0]["thread_id"] == "100"
+    assert data["messages"][0]["channel"] == "general"
+
+
+@pytest.mark.asyncio
+async def test_active_threads_included_via_discovery():
+    parent = _make_text(10, "general", guild=None)
+    thread = _make_thread(100, "topic", parent=parent)
+    guild = _make_guild(text_channels=[parent], active_threads=[thread])
+    parent.guild = guild
+    thread.history = _history_factory([_make_msg(9, "msg", channel=thread)])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute())
+    assert any(m["thread_id"] == "100" for m in data["messages"])
+
+
+@pytest.mark.asyncio
+async def test_archived_public_and_joined_private_threads():
+    parent = _make_text(10, "general", guild=None)
+    archived_pub = _make_thread(200, "arch-pub", parent=parent)
+    archived_priv = _make_thread(300, "arch-priv", parent=parent)
+    guild = _make_guild(text_channels=[parent])
+    parent.guild = guild
+    parent.archived_threads = MagicMock(return_value=_aiter([archived_pub, archived_priv]))
+    archived_pub.history = _history_factory([_make_msg(11, "pub", channel=archived_pub)])
+    archived_priv.history = _history_factory([_make_msg(12, "priv", channel=archived_priv)])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(include_threads=False, include_archived_threads=True))
+    ids = {m["thread_id"] for m in data["messages"]}
+    assert ids == {"200", "300"}
+    # The tool must request joined private archives only (joined=True).
+    parent.archived_threads.assert_any_call(private=True, joined=True, limit=50)
+    parent.archived_threads.assert_any_call(private=False, joined=False, limit=50)
+
+
+@pytest.mark.asyncio
+async def test_dedup_thread_from_active_and_archived():
+    parent = _make_text(10, "general", guild=None)
+    thread = _make_thread(100, "topic", parent=parent)
+    guild = _make_guild(text_channels=[parent], active_threads=[thread])
+    parent.guild = guild
+    # same thread also surfaced via archived enumeration
+    parent.archived_threads = MagicMock(return_value=_aiter([thread]))
+    thread.history = _history_factory([_make_msg(1, "msg", channel=thread)])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(include_archived_threads=True))
+    # fetched once despite two discovery paths
+    assert len(data["messages"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Partial failures, result shape, date filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_records_warning_and_returns_rest():
+    good = _make_text(10, "ok", guild=None)
+    bad = _make_text(20, "bad", guild=None)
+    guild = _make_guild(text_channels=[good, bad])
+    good.guild = guild
+    bad.guild = guild
+    good.history = _history_factory([_make_msg(1, "ok", channel=good)])
+
+    def _boom(**kwargs):
+        raise RuntimeError("boom")
+
+    bad.history = _boom
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute())
+    assert len(data["messages"]) == 1
+    assert data["warnings"]
+    assert any("fetch failed" in w for w in data["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_date_filtering_exclusive_bounds():
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    tc = _make_text(10, "a", guild=None)
+    guild = _make_guild(text_channels=[tc])
+    tc.guild = guild
+    tc.history = _history_factory([
+        _make_msg(1, "before", channel=tc, created_at=base),
+        _make_msg(2, "in", channel=tc, created_at=base.replace(hour=2)),
+        _make_msg(3, "after", channel=tc, created_at=base.replace(hour=5)),
+    ])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute(
+        since=base.isoformat(), until=base.replace(hour=5).isoformat(),
+    ))
+    ids = [int(m["message_id"]) for m in data["messages"]]
+    assert ids == [2]
+
+
+@pytest.mark.asyncio
+async def test_result_shape_fields():
+    tc = _make_text(10, "general", guild=None)
+    guild = _make_guild(gid=42, name="MyGuild", text_channels=[tc])
+    tc.guild = guild
+    author = _make_author(7, name="alice", display="Alice")
+    att = SimpleNamespace(filename="f.png", url="http://x/f.png")
+    emb = SimpleNamespace(type="rich", title="T", url="http://x")
+    tc.history = _history_factory([
+        _make_msg(
+            100, "hi", channel=tc, author=author, reply_to=99,
+            attachments=[att], embeds=[emb], mtype="reply",
+        )
+    ])
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute())
+    assert set(data.keys()) == {"guild", "window", "messages", "sources", "truncated", "warnings"}
+    assert data["guild"] == {"id": "42", "name": "MyGuild"}
+    assert data["truncated"] is False
+    m = data["messages"][0]
+    assert m["message_id"] == "100"
+    assert m["channel_id"] == "10"
+    assert m["channel"] == "general"
+    assert m["thread_id"] is None
+    assert m["author"] == "Alice"
+    assert m["author_id"] == "7"
+    assert m["reply_to"] == "99"
+    assert m["message_type"] == "reply"
+    assert m["attachments"] == [{"filename": "f.png", "url": "http://x/f.png"}]
+    assert m["embeds"] == [{"type": "rich", "title": "T", "url": "http://x"}]
+
+
+@pytest.mark.asyncio
+async def test_empty_result_when_no_sources():
+    guild = _make_guild()
+    tool, _ = _make_setup(guilds=[guild])
+    data = json.loads(await tool.execute())
+    assert data["messages"] == []
+    assert data["sources"] == {"scanned": 0, "skipped": 0}
+    assert data["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
+# DiscordChannel accessor + helper
+# ---------------------------------------------------------------------------
+
+
+def test_discord_channel_client_accessor_read_only():
+    ch = DiscordChannel(DiscordConfig(), MessageBus())
+    assert ch.client is None
+    fake = MagicMock()
+    ch._client = fake
+    assert ch.client is fake
+
+
+def test_is_channel_allowed_respects_allowlist():
+    ch = DiscordChannel(DiscordConfig(allow_channels=["10"]), MessageBus())
+    listed = SimpleNamespace(id=10, parent_id=None, parent=None)
+    unlisted = SimpleNamespace(id=20, parent_id=None, parent=None)
+    assert ch.is_channel_allowed(listed) is True
+    assert ch.is_channel_allowed(unlisted) is False
+
+
+def test_is_channel_allowed_empty_allowlist_allows_all():
+    ch = DiscordChannel(DiscordConfig(), MessageBus())
+    src = SimpleNamespace(id=999, parent_id=None, parent=None)
+    assert ch.is_channel_allowed(src) is True


### PR DESCRIPTION
Closes #15.

## Summary

Adds a bounded, read-only `discord_history` tool that lets foreground and cron-fired agent turns fetch past Discord messages from one configured guild. This fills the gap between the existing event-driven `on_message` flow and use cases such as catch-up, channel/thread summaries, and later periodic discourse synthesis.

This implements **only** the history-reading primitive and the minimum runtime plumbing it needs. Per the issue's out-of-scope list, no discourse-roundup skill, watermarking, persistent person profiles, or note writing is bundled here.

## Runtime plumbing (late-bound handle)

`AgentLoop` is constructed before `ChannelManager`, so the Discord client does not exist at tool-registration time. The implementation uses a late-bound runtime handle rather than passing a concrete client:

- **`DiscordRuntimeHandle`** (`nanobot/agent/tools/discord_history.py`) — a small mutable holder created before `AgentLoop` construction and bound to the live `DiscordChannel` after `ChannelManager` starts. It resolves the connected client at execution time, so tool registration never depends on a live client. The same bound handle is shared by isolated cron turns via the agent's tool registry.
- **`ToolContext.discord_runtime_handle`** field; threaded through `AgentLoop.__init__` → `from_config` → gateway.
- **Gateway** (`nanobot/cli/commands.py`) creates the handle when Discord is enabled in config, passes it into `AgentLoop.from_config`, and binds it to `channels.get_channel("discord")` after `ChannelManager` construction.
- **`DiscordChannel.client`** public read-only accessor + `is_channel_allowed()` helper reusing the existing `allow_channels` parent/thread semantics; the tool never reaches into `_client`.

## The `discord_history` tool

Read-only, `core` scope only (not subagent), with optional `discord` import so a missing Discord extra produces an actionable tool error rather than crashing startup.

- **Parameters:** `guild_id`, `channel_id`, `since`, `until` (ISO-8601, exclusive, UTC-normalized), `limit` (default 500 / max 2000), `per_source_limit` (default 200 / max 500), `include_threads` (default true), `include_archived_threads` (default false), `archived_thread_limit` (default 50 / max 200), `max_chars` (default 12000 / max 16000).
- **Validation:** numeric snowflakes, timezone-aware datetimes normalized to UTC, exclusive bounds, `since < until`, all caps in range — validated before any unbounded work.
- **Guild resolution:** exactly one guild per call; omission accepted only when the bot is in exactly one guild.
- **Source discovery (multi-source):** eligible `TextChannel`s, `ForumChannel` posts (threads), active threads via `guild.active_threads()`, and bounded archived public + joined-private threads. De-duplicated. Unjoined private archives are never enumerated (no `manage_threads`).
- **Permissions:** `view_channel` + `read_message_history` required per source; inaccessible sources skipped. Disallowed or inaccessible *direct* requests return a generic `not available to this bot configuration` error without revealing details.
- **Fetching:** `Messageable.history(after, before, limit)` with `oldest_first=True`; per-source cap applied while fetching, global cap stops fetching further sources. Deterministic global `(timestamp, message_id)` ascending order.
- **Result shape:** one structured JSON object with `guild`, `window`, `messages` (compact schema), `sources` (`scanned`/`skipped`), `truncated`, `warnings`. Partial results + warnings on per-source failures; explicit `max_chars` truncation metadata.
- **Errors:** missing `discord.py`, disabled/not-started Discord, and not-ready clients return actionable errors without crashing the gateway.

## Tests

35 unit tests in `tests/agent/tools/test_discord_history_tool.py` covering every acceptance criterion: lifecycle/readiness, guild ambiguity, allowlist (incl. parent-thread behavior), permissions, date validation, output ordering, global/per-source/char caps, text channels, forum posts, active threads, archived public/joined-private threads, de-duplication, partial failures, result shape, and missing optional dependency. Tests use spec-bound fakes so `isinstance` checks against real `discord.py` types work.

## Verification

```
uv run ruff check nanobot/agent/tools/discord_history.py nanobot/agent/tools/context.py \
  nanobot/agent/loop.py nanobot/channels/discord.py nanobot/cli/commands.py \
  tests/agent/tools/test_discord_history_tool.py   # All checks passed
uv run --extra dev python -m pytest tests/agent/tools/test_discord_history_tool.py -q   # 35 passed
```

Integration-checked that `ToolLoader` discovers the tool, registers it only when a handle is present, and excludes it from the `subagent` scope.

## Note

The 9 failures currently in `tests/channels/test_discord_channel.py` are **pre-existing** (verified via `git stash` — they fail identically on `main`) and caused by `discord.py` 2.7.1 version skew with those tests' fakes. They are unrelated to this change and out of scope for #15.